### PR TITLE
CRPL-3169 Replaced ethers package with web3 in unit parser and unit formatter

### DIFF
--- a/blockchain/ethereum/unit formatter/96f03be3-a29d-4637-aab1-6840bafeacb0.json
+++ b/blockchain/ethereum/unit formatter/96f03be3-a29d-4637-aab1-6840bafeacb0.json
@@ -1,24 +1,24 @@
 {
   "name": "blockchain/ethereum/Unit formatter",
-  "description": "Returns a string representation of value formatted with unit digits .\n\nSee: https://docs.ethers.io/v5/api/utils/display-logic/#utils-formatUnits",
+  "description": "Returns a string representation of value formatted with unit digits.\n\nEg:\n1. `units` receives \"1500000000000000000\"@0\n2. `decimal` is set to 18\n3. `result` sends out \"1.5\"@0",
   "interface": {
     "inputs": {
       "0d455460-c659-44c5-afd7-bdba5211c32d": {
-        "type": "{string: any}",
+        "type": "(string or number)",
         "name": "units",
-        "description": "The value as BigNumber"
+        "description": "Receives the value in units."
       },
       "6ffb69e8-3e06-43ed-b449-83880fdcedcf": {
         "type": "number",
         "name": "decimals",
-        "description": "The number of decimals to represent the unit.\nDefaults to 18."
+        "description": "Receives the number of decimals to represent the unit. \nDefaults to 18 (=\"ether\")."
       }
     },
     "outputs": {
       "aaa7049a-c2b9-4257-a583-eaf68de2c346": {
-        "type": "typeof `result` of `format BigNumber to string`",
+        "type": "string",
         "name": "result",
-        "description": "The string representation of value formatted with unit digits."
+        "description": "Sends out the string representation of value formatted with unit digits."
       }
     }
   },
@@ -101,7 +101,8 @@
   "keywords": {
     "ethers": null,
     "decimals": null,
-    "BigNumber": null
+    "BigNumber": null,
+    "BigInt": null
   },
   "original": "eb3f5e07-27f3-42dc-9ac1-60f747d6c1b5",
   "iconId": "eeec34e3-c832-4c7b-b045-62f82ebc3ddb",

--- a/blockchain/ethereum/unit formatter/internal/d2d49fe9-90aa-4f9b-acb1-6d42845412f9.json
+++ b/blockchain/ethereum/unit formatter/internal/d2d49fe9-90aa-4f9b-acb1-6d42845412f9.json
@@ -9,14 +9,14 @@
         }
       },
       "inputFunctions": {
-        "b3cea331-0e22-4273-be38-3a574b507611": "const ethers = require(\"ethers\");\nconst {units, decimals = 18} = data;\n\nconst result = ethers.utils.formatUnits(units.toString(), decimals);\n\noutputs[\"result\"](result, tag);"
+        "b3cea331-0e22-4273-be38-3a574b507611": "const {fromWei, unitMap} = require(\"web3\").utils;\nconst {units, decimals = 18} = data;\n\n    \nconst fromUnitName = Object.entries(unitMap)\n  .find(([unitName, value]) =>{\n    return value === `1${\"0\".repeat(decimals)}`\n  })?.[0];\n  \nif(!fromUnitName) {\n  throw new Error(\"Invalid value given for decimals\");\n}\n\nconst result = fromWei(units.toString(), fromUnitName);\n\noutputs[\"result\"](result, tag);"
       }
     }
   },
   "interface": {
     "inputs": {
       "b3cea331-0e22-4273-be38-3a574b507611": {
-        "type": "number",
+        "type": "{\n  \"units\": string,\n  \"decimals\": string\n}",
         "name": "units & decimals",
         "description": ""
       }
@@ -25,12 +25,12 @@
       "9efa481d-63ea-4735-b8df-06add0d6d1bc": {
         "type": "string",
         "name": "result",
-        "description": "The number converted to BigNumber"
+        "description": ""
       }
     }
   },
   "name": "blockchain/ethereum/Unit formatter/Internal",
-  "description": "\n",
+  "description": "See blockchain/ethereum/Unit formatter\n",
   "iconId": "cbb85c56-3c8f-4e5e-afdd-a9dd9e84385d",
   "original": "d81d132f-a682-42ab-b17e-436701e3974c",
   "attributes": {

--- a/blockchain/ethereum/unit parser/eb3f5e07-27f3-42dc-9ac1-60f747d6c1b5.json
+++ b/blockchain/ethereum/unit parser/eb3f5e07-27f3-42dc-9ac1-60f747d6c1b5.json
@@ -1,24 +1,24 @@
 {
   "name": "blockchain/ethereum/Unit parser",
-  "description": "Creates BigNumber representation of number units useing the specified amount of decimals.\n\nSee: https://docs.ethers.io/v5/api/utils/display-logic/#utils-parseUnits",
+  "description": "Converts the decimal string value of units to a string assuming unit decimal places.\n\nEg:\n1. `units` receives 1.5@0\n2. `decimals` is set to 18\n3. `results` sends out \"1500000000000000000\"",
   "interface": {
     "inputs": {
       "0d455460-c659-44c5-afd7-bdba5211c32d": {
-        "type": "number",
+        "type": "(string or number)",
         "name": "units",
-        "description": "The number of units"
+        "description": "Receives the number of units."
       },
       "6ffb69e8-3e06-43ed-b449-83880fdcedcf": {
         "type": "number",
         "name": "decimals",
-        "description": "The number of decimals to represent the unit"
+        "description": "Receives the number of decimals to represent the unit. \nDefaults to 18 (=\"ether\")."
       }
     },
     "outputs": {
       "aaa7049a-c2b9-4257-a583-eaf68de2c346": {
-        "type": "typeof `result` of `convert to BigNumber`",
+        "type": "string",
         "name": "result",
-        "description": "The BigNumber representation of value, parsed with unit digits."
+        "description": "Sends out the string representation of value parsed with unit digits."
       }
     }
   },
@@ -101,7 +101,8 @@
   "keywords": {
     "ethers": null,
     "decimals": null,
-    "BigNumber": null
+    "BigNumber": null,
+    "BigIng": null
   },
   "iconId": "eeec34e3-c832-4c7b-b045-62f82ebc3ddb",
   "attributes": {

--- a/blockchain/ethereum/unit parser/internal/d81d132f-a682-42ab-b17e-436701e3974c.json
+++ b/blockchain/ethereum/unit parser/internal/d81d132f-a682-42ab-b17e-436701e3974c.json
@@ -3,34 +3,34 @@
     "es6-node": {
       "dependencies": {
         "npm": {
-          "ethers": {
+          "web3": {
             "description": ""
           }
         }
       },
       "inputFunctions": {
-        "b3cea331-0e22-4273-be38-3a574b507611": "const ethers = require(\"ethers\");\nconst {units, decimals = 18} = data;\n\nconst result = ethers.utils.parseUnits(units.toString(), decimals);\n\noutputs[\"result\"](result, tag);"
+        "b3cea331-0e22-4273-be38-3a574b507611": "const {unitMap, toWei} = require(\"web3\").utils;\nconst {units, decimals = 18} = data;\n\nconst toUnitName = Object.entries(unitMap)\n  .find(([unitName, value]) =>{\n    return value === `1${\"0\".repeat(decimals)}`\n  })?.[0];\n  \nif(!toUnitName) {\n  throw new Error(\"Invalid value given for decimals\");\n}\n\nconst result = toWei(units.toString(), toUnitName);\n\noutputs[\"result\"](result, tag);"
       }
     }
   },
   "interface": {
     "inputs": {
       "b3cea331-0e22-4273-be38-3a574b507611": {
-        "type": "number",
+        "type": "{\n\"units\": number,\n\"decimals\": number\n}",
         "name": "units & deximals",
-        "description": "The number to convert to BigNumber"
+        "description": ""
       }
     },
     "outputs": {
       "9efa481d-63ea-4735-b8df-06add0d6d1bc": {
-        "type": "{string: any}",
+        "type": "string",
         "name": "result",
-        "description": "The number converted to BigNumber"
+        "description": ""
       }
     }
   },
   "name": "blockchain/ethereum/Unit parser/Internal",
-  "description": "Creates BigNumber representation of number units useing the specified amount of decimals.\n\n",
+  "description": "See blockchain/ethereum/Unit parser",
   "iconId": "cbb85c56-3c8f-4e5e-afdd-a9dd9e84385d",
   "attributes": {
     "internal": true,


### PR DESCRIPTION
Recently published ethers v6 introduced breaking changes causing exception in our prototypes. As we only used ethers for unit parser and unit formatter and web3 for any other blockchain operations I've chosen to switch these two prototypes also to web3 usage.